### PR TITLE
Updated scrot commands to use internal date format

### DIFF
--- a/.config/openbox/rc.xml
+++ b/.config/openbox/rc.xml
@@ -531,7 +531,7 @@
     <!-- Take a screenshot, say "Cheeeese!" -->
     <keybind key="Print">
       <action name="Execute">
-        <command>scrot ~/Pictures/Screenshot-$(date +%F_%T).png</command>
+        <command>scrot ~/Pictures/Screenshot-%Y-%m-%d_%H:%M:%S.png</command>
       </action>
     </keybind>
     <keybind key="W-Print">

--- a/.config/openbox/scripts/screenshot.sh
+++ b/.config/openbox/scripts/screenshot.sh
@@ -9,11 +9,12 @@ option2="window"
 options="$option0\n$option1\n$option2"
 
 selected="$(echo -e "$options" | rofi -lines 3 -dmenu -p "scrot")"
+filename="Screenshot-%Y-%m-%d_%H:%M:%S.png"
 case $selected in
     $option0)
-        cd ~/Pictures/ && sleep 1 && scrot;;
+        cd ~/Pictures/ && sleep 1 && scrot "$filename";;
     $option1)
-        cd ~/Pictures/ && scrot -s;;
+        cd ~/Pictures/ && scrot -s "$filename";;
     $option2)
-        cd ~/Pictures/ && sleep 1 && scrot -u;;
+        cd ~/Pictures/ && sleep 1 && scrot -u "$filename";;
 esac


### PR DESCRIPTION
Hello,

There is a filename issue when creating screenshots using the print key on the keyboard. The file is created in the ~/Pictures directory but with an undesired filename and without extension. The filename generated is the following:

```
Screenshot-(date
```

Based on the output of the included command `Screenshot-$(date +%F_%T).png`, I have changed the rc.xml and screenshot.sh files to generate the correct filename.

My current setup is default openbox installed using EndeavourOS_Atlantis_neo-21_5.iso

Please let me know if you have any comments or suggestions.